### PR TITLE
Remove Stove link

### DIFF
--- a/stove.md
+++ b/stove.md
@@ -9,5 +9,3 @@ permalink: /stove/
 It ships a [Kettle](/kettle) adapter, which lets it communicate with
 Hearthstone simulators such as [Fireplace](/fireplace/) to create and simulate
 games.
-
-[Source code](https://github.com/HearthSim/stove/)


### PR DESCRIPTION
Remove stove link, as it's no longer publicly available.